### PR TITLE
It's a good strategy to also support ED448 rather than just ED25519 for

### DIFF
--- a/draft-ietf-dnsop-algorithm-update.xml
+++ b/draft-ietf-dnsop-algorithm-update.xml
@@ -296,7 +296,10 @@
 	  target="RFC8032"/>, <xref target="RFC8080"/>).  It is
 	  expected that ED25519 will become the future RECOMMENDED
 	  default algorithm once there's enough support for this
-	  algorithm in the deployed DNSSEC validators.
+	  algorithm in the deployed DNSSEC validators. However, relying on
+	  a single Edwards-curve is not a proper strategy. Hence,
+	  it is recommended to support both ED25519 and ED448 in case
+	  of an unforseen security flaw with ED25519 in the future.
 	</t>
 
       </section>


### PR DESCRIPTION
Edwardian Curves in case of an unforseen flaw with ED25519 in the future. This follows a discussion with Daniel Kahn Gillmor in the corridor during an IETF meeting where he mentioned to me that in case of a flaw in ED25519, this will cause issues in the future.

I've been pushing for ED448 in SSH as well (OpenSSH) to avoid this risk as
well (see: https://tools.ietf.org/html/draft-ietf-curdle-ssh-ed25519-ed448-04).

